### PR TITLE
break vhost example configuration out to an operator file

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,10 @@ Add the route so you can access the server once its deployed
 ```
 sudo route add -net 10.244.0.0/16 gw 192.168.50.6
 ```
+Configure a vhost in manifests/vhost.yml
 Run the deployment
 ```
-bosh -e vbox -d nginx deploy manifests/deployment.yml
+bosh -e vbox -d nginx deploy manifests/deployment.yml -o manifests/vhost.yml
 ```
 Watch as the director creates an nginx instance, you can visit the static page here: http://10.244.0.50
 

--- a/manifests/deployment.yml
+++ b/manifests/deployment.yml
@@ -22,29 +22,7 @@ instance_groups:
   jobs:
   - name: nginx
     release: nginx
-    properties:
-      nginx_worker_processes: 1
-      nginx_worker_connections: 1024
-      nginx_servers:
-      - server_name: localtest.local
-        docroot: /var/vcap/store/nginx/www/document_root
-        port: 80
-        index: "index.php index.html index.htm"
-        access_log: /var/vcap/sys/log/nginx/access.log
-        error_log: /var/vcap/sys/log/nginx/error.log
-        custom_data: |
-                     location / {
-                         try_files $uri $uri/ =404;
-                     }
-                     location ~ \.php$ {
-                         try_files $uri =404;
-                         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-                         fastcgi_pass 127.0.0.1:9000;
-                         fastcgi_index index.php;
-                         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-                         include fastcgi_params;
-                     }
-
+    properties: {}
 
 update:
   canaries: 1

--- a/manifests/vhosts.yml
+++ b/manifests/vhosts.yml
@@ -1,0 +1,25 @@
+- type: replace
+  path: /instance_groups/name=nginx/jobs/name=nginx/properties
+  value:
+      nginx_worker_processes: 2
+      nginx_worker_connections: 1024
+      nginx_servers:
+      - server_name: foo.oakton.digital
+        docroot: /var/vcap/store/nginx/www/document_root
+        port: 80
+        index: "index.php index.html index.htm"
+        access_log: /var/vcap/sys/log/nginx/access.log
+        error_log: /var/vcap/sys/log/nginx/error.log
+        custom_data: |
+                     location / {
+                         try_files $uri $uri/ =404;
+                     }
+                     location ~ \.php$ {
+                         try_files $uri =404;
+                         fastcgi_split_path_info ^(.+\.php)(/.+)$;
+                         fastcgi_pass 127.0.0.1:9000;
+                         fastcgi_index index.php;
+                         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+                         include fastcgi_params;
+                     }
+


### PR DESCRIPTION
To make it easier for consumers of this release, I have split the vhost configuration out to an operators file.

This allows consumers to supply their own operator files if they want.